### PR TITLE
fix(proxy): use tagged Caddy image

### DIFF
--- a/structure/files/rancher.bootstrap.template
+++ b/structure/files/rancher.bootstrap.template
@@ -40,7 +40,7 @@ rancher:
         - io.rancher.os.after=network
 
     proxy:
-      image: abiosoft/caddy
+      image: abiosoft/caddy:0.8.3
       restart: always
       volumes:
         - /etc/Caddyfile:/etc/Caddyfile


### PR DESCRIPTION
Motivation: The setup does not work anymore, because Caddy 0.9 came out and has breaking changes. Symptoms were, that websockets didn't work anymore, and worker-agents are communicating through websockets, so hosts never appeared in Rancher.

This PR sets the Caddy image to the latest 0.8 version