### PR TITLE
fix(cloudwatch): add cloudwatch log groups

### DIFF
--- a/structure/rancher.tf
+++ b/structure/rancher.tf
@@ -35,6 +35,14 @@ variable "cloudwatch_aws_secret_key" {
   type = "string"
 }
 
+resource "aws_cloudwatch_log_group" "rancher" {
+  name = "rancher"
+}
+
+resource "aws_cloudwatch_log_group" "rancher-system" {
+  name = "rancher-system"
+}
+
 resource "aws_key_pair" "rancher_key" {
   key_name = "rancher"
   public_key = "${var.rancher_public_key}"


### PR DESCRIPTION
The cloudwatch log groups that will be used here https://github.com/upfrontIO/infrastructure/blob/master/structure/files/rancher.bootstrap.template#L75 and here https://github.com/upfrontIO/infrastructure/blob/master/structure/files/rancher.bootstrap.template#L90 need to be created first.